### PR TITLE
Make hints proc-able

### DIFF
--- a/lib/dead_simple_cms/attribute/type/base.rb
+++ b/lib/dead_simple_cms/attribute/type/base.rb
@@ -22,7 +22,7 @@ module DeadSimpleCMS
 
         VALID_INPUT_TYPES = [:string, :text, :select, :file, :radio, :datetime].freeze
 
-        attr_reader   :hint, :input_type, :group_hierarchy, :required
+        attr_reader   :input_type, :group_hierarchy, :required
         attr_accessor :section
 
         def initialize(identifier, options={})
@@ -40,6 +40,10 @@ module DeadSimpleCMS
         # Public: The identifier on the section level. It must be unique amongst the groups.
         def section_identifier
           (group_hierarchy + [self]).map(&:identifier).join("_").to_sym
+        end
+
+        def hint
+          @hint.is_a?(Proc) ? @hint.call : @hint
         end
 
         def default

--- a/spec/dead_simple_cms/attribute/type/base_spec.rb
+++ b/spec/dead_simple_cms/attribute/type/base_spec.rb
@@ -57,7 +57,22 @@ describe DeadSimpleCMS::Attribute::Type::Base do
       its (:root_group?) { should be true }
     end
   end
-  
+
+  describe "#hint" do
+
+    its(:hint) { should == "some hint" }
+
+    context "when hint is passed in as a Proc" do
+      before(:each) do
+        delayed_hint = 123
+        subject.instance_variable_set(:@hint, lambda { delayed_hint } )
+      end
+
+      its(:hint) { should == 123 }
+
+    end
+  end
+
   describe "#default" do
 
     its (:default) { should == 413 }


### PR DESCRIPTION
Changes:
- hint now accepts a proc, behaving similarly to default

Testing
- specs pass
