### PR TITLE
Do not hardcode cells gem version

### DIFF
--- a/dead_simple_cms.gemspec
+++ b/dead_simple_cms.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activesupport", ">= 3.0"
   gem.add_dependency "activemodel",   ">= 3.0"
-  gem.add_dependency "cells", "3.8.5"
+  gem.add_dependency "cells"
 
   gem.add_development_dependency "simple_form"
   gem.add_development_dependency "rails", ">= 3.0"


### PR DESCRIPTION
I think it was mistakenly specified by @iafonov in https://github.com/iafonov/dead_simple_cms/commit/9e6002e22b65b6c33405ca42ad259208821f2e87

@astashov please review.
