### PR TITLE
Add lazy initialization of sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ class Mixbook::DeadSimpleCMS::FileUploader < ::DeadSimpleCMS::FileUploader::Base
 end
 ```
 
+Please note that section blocks are lazy, and only will be executed on the first access to the values,
+e.g. by `DeadSimpleCMS.sections.site_annoucement`. You can force execution by `DeadSimpleCMS::Section#build_block!`
+
 Accessing Values
 -----
 

--- a/lib/dead_simple_cms/section.rb
+++ b/lib/dead_simple_cms/section.rb
@@ -23,9 +23,14 @@ module DeadSimpleCMS
       @path       = options[:path]
       @root_group = Group.root # The root group for the section.
       @fragments  = Array.wrap(options[:fragments])
+      @block = block
       add_group(@root_group)
+      @is_loaded = false
+    end
 
-      build(&block) if block_given?
+    def build_block!
+      build(&@block) if @block && !@is_loaded
+      @is_loaded = true
     end
 
     # Public: Update the sections with the params and return the updated sections.

--- a/lib/dead_simple_cms/util/identifier/dictionary.rb
+++ b/lib/dead_simple_cms/util/identifier/dictionary.rb
@@ -46,10 +46,31 @@ module DeadSimpleCMS
         end
 
         def [](key)
-          super(to_identifier(key))
+          result = super(to_identifier(key))
+          maybe_build_block(result)
+          result
+        end
+
+        def each(&block)
+          super do |k, v|
+            maybe_build_block(v)
+            block[k, v]
+          end
+        end
+
+        def values
+          results = super
+          results.each do |result|
+            maybe_build_block(result)
+          end
+          results
         end
 
         private
+
+        def maybe_build_block(value)
+          value.build_block! if value.respond_to?(:build_block!)
+        end
 
         # Private: Cast an identifier or other object into an identifier.
         def to_identifier(identifier)

--- a/spec/setup/shared.rb
+++ b/spec/setup/shared.rb
@@ -3,7 +3,7 @@ shared_context :sample_section do
   let(:section) do
     # Site announcement is an example of a potential use case. It leverages a lot of the functionality of the
     # library, hence why we are teting against it.
-    DeadSimpleCMS::Section.new(:site_announcement, :path => "/") do
+    section = DeadSimpleCMS::Section.new(:site_announcement, :path => "/") do
       boolean :show_default, :default => false
       string :coupon_code
       group(:top_bar) do
@@ -29,6 +29,8 @@ shared_context :sample_section do
         end
       end
     end
+    section.build_block!
+    section
   end
 
 end


### PR DESCRIPTION
/cc @grumpy, PTAL

Since DeadSimpleCMS is usually configured in config/initializers, using
some app models there though sometimes required, could lead to circular
references. It's better to lazy evaluate sections' blocks, so they will
be loaded only when necessary.