### PR TITLE
Fix deprecation warning in Rails 3.2

### DIFF
--- a/lib/dead_simple_cms/util/identifier.rb
+++ b/lib/dead_simple_cms/util/identifier.rb
@@ -17,14 +17,10 @@ module DeadSimpleCMS
         attr_accessor :label, :identifier
       end
 
-      module InstanceMethods
-
-        def initialize(identifier, options={})
-          @identifier = identifier.to_sym
-          @label = options[:label] || identifier.to_s.titleize
-          super()
-        end
-
+      def initialize(identifier, options={})
+        @identifier = identifier.to_sym
+        @label = options[:label] || identifier.to_s.titleize
+        super()
       end
 
       module ClassMethods

--- a/lib/dead_simple_cms/version.rb
+++ b/lib/dead_simple_cms/version.rb
@@ -1,3 +1,3 @@
 module DeadSimpleCMS
-  VERSION = "0.12.9"
+  VERSION = "0.12.10"
 end


### PR DESCRIPTION
@Aryk We are getting deprecation warnings in the mixbook_com codebase on Rails 3.2. Can you review this PR, merge and push a new gem?