### PR TITLE
Use specified default value for boolean attributes

### DIFF
--- a/dead_simple_cms.gemspec
+++ b/dead_simple_cms.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "simple_form"
   gem.add_development_dependency "rails", ">= 3.0"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec",  "2.11.0"
   gem.add_development_dependency "sqlite3"
 
   gem.description = <<-description

--- a/lib/dead_simple_cms/attribute/type/all.rb
+++ b/lib/dead_simple_cms/attribute/type/all.rb
@@ -19,7 +19,8 @@ module DeadSimpleCMS
         self.default_input_type = :check_box
 
         def initialize(identifier, options={})
-          options.update(:collection => [true, false], :default => false)
+          options = {collection: [true, false], default: false}.merge(options)
+
           super
         end
 

--- a/lib/dead_simple_cms/version.rb
+++ b/lib/dead_simple_cms/version.rb
@@ -1,3 +1,3 @@
 module DeadSimpleCMS
-  VERSION = "0.12.10"
+  VERSION = "0.12.11"
 end

--- a/spec/dead_simple_cms/attribute/type/all_spec.rb
+++ b/spec/dead_simple_cms/attribute/type/all_spec.rb
@@ -76,6 +76,16 @@ describe DeadSimpleCMS::Attribute::Type::Boolean do
 
   its(:default_input_type) { should == :check_box }
 
+  describe '#initialize' do
+    context 'with default option specified' do
+      let(:options) { {default: true} }
+
+      it 'has default options set to true' do
+        expect(subject.default).to be true
+      end
+    end
+  end
+
   describe "#convert_value" do
     it %{should convert "true" or "1" into TrueClass} do
       ["True", "true", "1", "TruE"].each do |str|


### PR DESCRIPTION
### Summary

- Fix issue with `default` value for boolean fields being ignored. [[Hash#update](https://apidock.com/ruby/Hash/update)]

