### PR TITLE
Show image directly on form instead of preview link

### DIFF
--- a/lib/dead_simple_cms/rails/action_view/form_builders/simple_form.rb
+++ b/lib/dead_simple_cms/rails/action_view/form_builders/simple_form.rb
@@ -20,7 +20,10 @@ module DeadSimpleCMS
           def attribute(attribute)
             as = AS_LOOKUP[attribute.input_type]
             hint = attribute.hint.to_s.dup
-            hint << %{ <a href="#{attribute.value}" target="_blank">preview</a>} if attribute.is_a?(Attribute::Type::Image)
+            if attribute.is_a?(Attribute::Type::Image) && attribute.value.present?
+              hint << %{ <img src="#{attribute.value}" > }
+            end
+
             options = {:required => attribute.required, :hint => hint, :as => as, :label => attribute.label}
             if attribute.length
               options[:input_html] = {maxlength: attribute.length}

--- a/lib/dead_simple_cms/version.rb
+++ b/lib/dead_simple_cms/version.rb
@@ -1,3 +1,3 @@
 module DeadSimpleCMS
-  VERSION = "0.12.11"
+  VERSION = "0.12.12"
 end


### PR DESCRIPTION
### Summary

* Updates `Image` attributes rendering: image is displayed instead of preview link.